### PR TITLE
Traverse.hs: substitute NBSP (0xC2 0xA0) to SP (0x20)

### DIFF
--- a/src/System/Directory/Layout/Traverse.hs
+++ b/src/System/Directory/Layout/Traverse.hs
@@ -54,11 +54,11 @@ changeDir fp = local (</> fp)
 -- % tree
 -- .
 -- ├── baz
--- │   └── twey
+-- │   └── twey
 -- └── foo
 --     ├── bar
---     │   ├── quuz
---     │   └── tatata
+--     │   ├── quuz
+--     │   └── tatata
 --     └── quux
 -- @
 --
@@ -88,11 +88,11 @@ makeDirectory p = ask >>= \d -> anyfail $ createDirectory (d </> p)
 -- % tree
 -- .
 -- ├── baz
--- │   └── twey
+-- │   └── twey
 -- └── foo
 --     ├── bar
---     │   ├── quuz
---     │   └── tatata
+--     │   ├── quuz
+--     │   └── tatata
 --     └── quux
 -- @
 --


### PR DESCRIPTION
Before patching ./setup haddock failed to parse some comments:

```
 100% (  3 /  3) in 'System.Directory.Layout.Internal'
doc comment parse failed:  Make layout as specified

 For example, suppose you are in an empty directory

 @
 % tree
 .
 @
```

After patch everything renders correctly.

Haddock-bug: http://trac.haskell.org/haddock/ticket/250
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
